### PR TITLE
andys temporary patch to fix encoding differences

### DIFF
--- a/R/geoboundaries.R
+++ b/R/geoboundaries.R
@@ -82,7 +82,12 @@ geoboundaries <- function(country = NULL, adm_lvl = "adm0",
                            version = version)
     shps <- get_shp_from_links(links)
     path <- paste0("/vsizip/", shps)
-    res <- read_gb(path, quiet = quiet, options = "ENCODING=WINDOWS-1252")
+    
+    #andys temporary patch to fix encoding differences in geoboundaries
+    encoding = "WINDOWS-1252"
+    if ( tolower(substr(type,1,1)) == "s" ) encoding = "UTF-8"    
+    
+    res <- read_gb(path, quiet = quiet, options=paste0("ENCODING=",encoding) )
   }
   res
 }


### PR DESCRIPTION
Hi Ahmadou,
Here's a potential patch for #4 .
I've tested it out and it seems to work. i.e. it is now running in https://andysouth.shinyapps.io/afriadmin-compare/ and seems to format all accents correctly for simple and precise.
It's probably just a temporary solution until geoboundaries sort consistent encoding see wmgeolab/rgeoboundaries#138
Thanks,
Andy 