### PR TITLE
Resolve missing dependency and add non-standard folder to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -45,3 +45,4 @@ _dev\.R$
 ^LICENSE\.md$
 ^data\-raw/*
 ^inst/*
+^CRAN/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     glue,
     memoise,
     countrycode (>= 1.2.0),
-    lifecycle
+    lifecycle,
+    hoardr
 Suggests:
     roxygen2,
     knitr,
@@ -36,6 +37,6 @@ Suggests:
     testthat,
     covr,
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 X-schema.org-applicationCategory: Data Access
 X-schema.org-keywords: geoboundaries, boundaries, gis, map, geographic, data, spatial, dataset

--- a/man/rgeoboundaries-package.Rd
+++ b/man/rgeoboundaries-package.Rd
@@ -8,6 +8,14 @@
 \description{
 R client to access geoBoundaries API
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/wmgeolab/rgeoboundaries}
+  \item Report bugs at \url{https://github.com/wmgeolab/rgeoboundaries/issues}
+}
+
+}
 \author{
 \email{mail@ahmadoudicko.com}
 }


### PR DESCRIPTION
This solves two issues:

1. The missing hoardr dependency
2. The non-standard directory (CRAN)

The following test fails for me but is beyond the scope of my contribution: 

```r
test_that("Downloaded data are cached", {
  gb_clear_cache()
  expect_equal(length(gb_list_cache()), 0)
  p <- gb_adm0(country = "Mali")
  expect_gte(length(gb_list_cache()), 1)
})

```

Thank you for your consideration!